### PR TITLE
Fix typo dsn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,5 +71,5 @@ Example:
 # .env
 
 # Enable compression, and sleep for 0.8 seconds during loops if the queue is empty
-MESSENGER_TRANSPORT_DSN="filesystem:/%kernel.project_dir%/var/queue/default?compress=true&loop_sleep=800000"
+MESSENGER_TRANSPORT_DSN="filesystem://%kernel.project_dir%/var/queue/default?compress=true&loop_sleep=800000"
 ```


### PR DESCRIPTION
A little typo in DSN on documentation. It will be ```filesystem:///folder/``` and no ```filesystem://folder/```.